### PR TITLE
SLING-7604 - ContentDeploymentTest sometimes fails on Jenkins

### DIFF
--- a/eclipse/eclipse-test/pom.xml
+++ b/eclipse/eclipse-test/pom.xml
@@ -96,78 +96,42 @@
                         <configuration>
                             <portNames>
                                 <portName>http.port</portName>
-                                <portName>jetty.stop.port</portName>
                             </portNames>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>slingstart-maven-plugin</artifactId>
+                <version>1.8.2</version>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
-                        <id>prepare-launchpad</id>
-                        <phase>pre-integration-test</phase>
+                        <id>start-container</id>
                         <goals>
-                            <goal>copy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <artifactItems>
-                        <artifactItem>
-                            <groupId>org.apache.sling</groupId>
-                            <artifactId>org.apache.sling.launchpad</artifactId>
-                            <version>7</version>
-                            <type>war</type>
-                            <overWrite>false</overWrite>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <destFileName>sling.war</destFileName>
-                        </artifactItem>
-                    </artifactItems>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>7.6.15.v20140411</version>
-                <configuration>
-                    <war>${project.build.directory}/sling.war</war>
-                    <connectors>
-                        <connector
-                            implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                            <port>${http.port}</port>
-                        </connector>
-                    </connectors>
-                    <stopKey>SLING_IT_STOP_KEY</stopKey>
-                    <stopPort>${jetty.stop.port}</stopPort>
-                    <contextPath>/</contextPath>
-                    <daemon>true</daemon>
-                    <systemProperties>
-                        <force>true</force>
-                        <systemProperty>
-                            <name>user.dir</name>
-                            <value>${project.build.directory}</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>jetty-run</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run-war</goal>
+                            <goal>start</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jetty-stop</id>
-                        <phase>post-integration-test</phase>
+                        <id>stop-container</id>
                         <goals>
                             <goal>stop</goal>
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <servers>
+                        <server>
+                            <port>${http.port}</port>
+                        </server>
+                    </servers>
+                    <launchpadDependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.starter</artifactId>
+                        <version>11</version>
+                    </launchpadDependency>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/JcrFullCoverageAggregatesDeploymentTest.java
+++ b/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/JcrFullCoverageAggregatesDeploymentTest.java
@@ -237,10 +237,10 @@ public class JcrFullCoverageAggregatesDeploymentTest {
         project.createVltFilterWithRoots("/content");
 
         // create .content.xml structure
-        InputStream contentXml = getClass().getResourceAsStream("content-nested-structure.xml");
+        InputStream contentXml = getClass().getResourceAsStream("content-nested-structure-ordered-nodes.xml");
         project.createOrUpdateFile(Path.fromPortableString("jcr_root/content/test-root/en.xml"), contentXml);
 
-        Matcher<Node> postConditions = allOf(hasPath("/content/test-root/en"), hasPrimaryType("sling:Folder"),
+        Matcher<Node> postConditions = allOf(hasPath("/content/test-root/en"), hasPrimaryType("sling:OrderedFolder"),
                 hasMixinTypes("mix:language"), hasChildrenNames("message", "error", "warning"));
 
         final RepositoryAccessor repo = new RepositoryAccessor(config);

--- a/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/content-nested-structure-ordered-nodes.xml
+++ b/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/content-nested-structure-ordered-nodes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or
+    more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information regarding
+    copyright ownership. The ASF licenses this file to you under the
+    Apache License, Version 2.0 (the "License"); you may not use
+    this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+    applicable law or agreed to in writing, software distributed
+    under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:mixinTypes="[mix:language]"
+    jcr:primaryType="sling:OrderedFolder"
+    jcr:language="en">
+    <message
+        jcr:primaryType="nt:unstructured"
+        sling:key="message"
+        sling:value="Message">
+    </message>
+    <error
+        jcr:primaryType="nt:unstructured"
+        sling:key="error"
+        sling:value="Error">
+    </error>
+    <warning
+        jcr:primaryType="nt:unstructured"
+        sling:key="warning"
+        sling:value="Warning">
+    </warning>
+</jcr:root>

--- a/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/helpers/ExternalSlingLaunchpad.java
+++ b/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/helpers/ExternalSlingLaunchpad.java
@@ -55,6 +55,7 @@ public class ExternalSlingLaunchpad extends ExternalResource {
 
         HttpClient client = new HttpClient();
         client.getState().setCredentials(new AuthScope(config.getHostname(), config.getPort()), creds);
+        client.getParams().setAuthenticationPreemptive(true);
 
         long cutoff = System.currentTimeMillis() + MAX_WAIT_TIME_MS;
 


### PR DESCRIPTION
Switch to Sling 11 for ITs in hopes of increasing the success rate.

- use the slingstart-maven-plugin
- use preemptive authentication for the ExternalSlingLaunchpad ready check
- for the nodes reordering tests use an node type that is actually ordered to make
  sure the assertions are relevant.