### PR TITLE
SLING-7605 - ContentDeploymentTest sometimes fails on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node('ubuntu') {
             withMaven(maven: mvnVersion, jdk: javaVersion, options: [artifactsPublisher(disabled: true)]) {
                 timeout(20) {
                     wrap([$class: 'Xvfb']) {
-                        sh 'mvn -f eclipse clean verify'
+                        sh 'mvn -f eclipse clean verify -Ddebug'
                     }
                     // workaround for https://issues.jenkins-ci.org/browse/JENKINS-55889
                     junit 'eclipse/**/surefire-reports/*.xml' 

--- a/eclipse/eclipse-m2e-test/pom.xml
+++ b/eclipse/eclipse-m2e-test/pom.xml
@@ -53,6 +53,26 @@
                     <manifestFile>META-INF/MANIFEST.MF</manifestFile>
                 </archive>
             </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <configuration>
+                <dependency-resolution>
+                    <extraRequirements>
+                        <requirement>
+                            <type>eclipse-plugin</type>
+                            <id>org.slf4j.binding.simple</id>
+                            <versionRange>0.0.0</versionRange>
+                        </requirement>
+                        <requirement>
+                            <type>eclipse-plugin</type>
+                            <id>org.slf4j.apis.log4j</id>
+                            <versionRange>0.0.0</versionRange>
+                        </requirement>
+                    </extraRequirements>
+                </dependency-resolution>
+            </configuration>
         </plugin>        
     </plugins>
   </build>  

--- a/eclipse/eclipse-test/META-INF/MANIFEST.MF
+++ b/eclipse/eclipse-test/META-INF/MANIFEST.MF
@@ -35,7 +35,8 @@ Import-Package: javax.jcr,
  org.apache.jackrabbit.util,
  org.apache.sling.ide.jcr,
  org.eclipse.wst.validation,
- org.osgi.service.event;version="1.3.0"
+ org.osgi.service.event;version="1.3.0",
+ org.slf4j
 Bundle-Activator: org.apache.sling.ide.test.impl.Activator
 Bundle-ActivationPolicy: lazy
 Export-Package: org.apache.sling.ide.test.impl.helpers;x-friends:="org.apache.sling.ide.eclipse-m2e-test"

--- a/eclipse/eclipse-test/pom.xml
+++ b/eclipse/eclipse-test/pom.xml
@@ -96,78 +96,42 @@
                         <configuration>
                             <portNames>
                                 <portName>http.port</portName>
-                                <portName>jetty.stop.port</portName>
                             </portNames>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>slingstart-maven-plugin</artifactId>
+                <version>1.8.2</version>
+                <extensions>true</extensions>
                 <executions>
                     <execution>
-                        <id>prepare-launchpad</id>
-                        <phase>pre-integration-test</phase>
+                        <id>start-container</id>
                         <goals>
-                            <goal>copy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <artifactItems>
-                        <artifactItem>
-                            <groupId>org.apache.sling</groupId>
-                            <artifactId>org.apache.sling.launchpad</artifactId>
-                            <version>7</version>
-                            <type>war</type>
-                            <overWrite>false</overWrite>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <destFileName>sling.war</destFileName>
-                        </artifactItem>
-                    </artifactItems>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>7.6.15.v20140411</version>
-                <configuration>
-                    <war>${project.build.directory}/sling.war</war>
-                    <connectors>
-                        <connector
-                            implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                            <port>${http.port}</port>
-                        </connector>
-                    </connectors>
-                    <stopKey>SLING_IT_STOP_KEY</stopKey>
-                    <stopPort>${jetty.stop.port}</stopPort>
-                    <contextPath>/</contextPath>
-                    <daemon>true</daemon>
-                    <systemProperties>
-                        <force>true</force>
-                        <systemProperty>
-                            <name>user.dir</name>
-                            <value>${project.build.directory}</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>jetty-run</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run-war</goal>
+                            <goal>start</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>jetty-stop</id>
-                        <phase>post-integration-test</phase>
+                        <id>stop-container</id>
                         <goals>
                             <goal>stop</goal>
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <servers>
+                        <server>
+                            <port>${http.port}</port>
+                        </server>
+                    </servers>
+                    <launchpadDependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.starter</artifactId>
+                        <version>11</version>
+                    </launchpadDependency>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/eclipse/eclipse-test/pom.xml
+++ b/eclipse/eclipse-test/pom.xml
@@ -62,6 +62,16 @@
                                 <id>org.apache.sling.ide.sightly-feature</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.slf4j.binding.simple</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.slf4j.apis.log4j</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
                         </extraRequirements>
                     </dependency-resolution>
                 </configuration>
@@ -76,6 +86,9 @@
                     <argLine>-XX:MaxPermSize=512m ${ui.test.args}</argLine>
                     <systemProperties>
                         <launchpad.http.port>${http.port}</launchpad.http.port>
+                        <org.slf4j.simpleLogger.showDateTime>true</org.slf4j.simpleLogger.showDateTime>
+                        <org.slf4j.simpleLogger.dateTimeFormat>yyyy-MM-dd HH:mm:ss:SSS Z</org.slf4j.simpleLogger.dateTimeFormat>
+                        <org.slf4j.simpleLogger.defaultLogLevel>${defaultLogLevel}</org.slf4j.simpleLogger.defaultLogLevel>
                     </systemProperties>
                     <environmentVariables>
                         <SWT_GTK3>0</SWT_GTK3>
@@ -138,6 +151,7 @@
 
     <properties>
         <ui.test.args></ui.test.args>
+        <defaultLogLevel>INFO</defaultLogLevel>
     </properties>
 
     <profiles>
@@ -152,6 +166,28 @@
             <properties>
                 <ui.test.args>-XstartOnFirstThread</ui.test.args>
             </properties>
+        </profile>
+        <profile>
+            <id>debug</id>
+            <activation>
+                <property>
+                    <name>debug</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-surefire-plugin</artifactId>
+                        <version>${tycho.version}</version>
+                        <configuration>
+                            <systemProperties>
+                                <org.slf4j.simpleLogger.log.org.apache.sling>debug</org.slf4j.simpleLogger.log.org.apache.sling>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/JcrFullCoverageAggregatesDeploymentTest.java
+++ b/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/JcrFullCoverageAggregatesDeploymentTest.java
@@ -237,10 +237,10 @@ public class JcrFullCoverageAggregatesDeploymentTest {
         project.createVltFilterWithRoots("/content");
 
         // create .content.xml structure
-        InputStream contentXml = getClass().getResourceAsStream("content-nested-structure.xml");
+        InputStream contentXml = getClass().getResourceAsStream("content-nested-structure-ordered-nodes.xml");
         project.createOrUpdateFile(Path.fromPortableString("jcr_root/content/test-root/en.xml"), contentXml);
 
-        Matcher<Node> postConditions = allOf(hasPath("/content/test-root/en"), hasPrimaryType("sling:Folder"),
+        Matcher<Node> postConditions = allOf(hasPath("/content/test-root/en"), hasPrimaryType("sling:OrderedFolder"),
                 hasMixinTypes("mix:language"), hasChildrenNames("message", "error", "warning"));
 
         final RepositoryAccessor repo = new RepositoryAccessor(config);

--- a/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/content-nested-structure-ordered-nodes.xml
+++ b/eclipse/eclipse-test/src/org/apache/sling/ide/test/impl/content-nested-structure-ordered-nodes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or
+    more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information regarding
+    copyright ownership. The ASF licenses this file to you under the
+    Apache License, Version 2.0 (the "License"); you may not use
+    this file except in compliance with the License. You may obtain
+    a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+    applicable law or agreed to in writing, software distributed
+    under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions
+    and limitations under the License.
+-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:mixinTypes="[mix:language]"
+    jcr:primaryType="sling:OrderedFolder"
+    jcr:language="en">
+    <message
+        jcr:primaryType="nt:unstructured"
+        sling:key="message"
+        sling:value="Message">
+    </message>
+    <error
+        jcr:primaryType="nt:unstructured"
+        sling:key="error"
+        sling:value="Error">
+    </error>
+    <warning
+        jcr:primaryType="nt:unstructured"
+        sling:key="warning"
+        sling:value="Warning">
+    </warning>
+</jcr:root>

--- a/eclipse/target-definition/org.apache.sling.ide.target-definition-dev.target
+++ b/eclipse/target-definition/org.apache.sling.ide.target-definition-dev.target
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><!--
     Licensed to the Apache Software Foundation (ASF) under one or
     more contributor license agreements. See the NOTICE file
     distributed with this work for additional information regarding
@@ -14,8 +13,7 @@
     WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions
     and limitations under the License.
--->
-<?pde version="3.8"?><target name="Sling IDE Tools" sequenceNumber="52">
+--><?pde version="3.8"?><target name="Sling IDE Tools" sequenceNumber="53">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.0.20150526-2032"/>
@@ -23,14 +21,16 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
-<unit id="org.apache.commons.collections" version="3.2.0.v2013030210310"/>
+<unit id="org.apache.commons.collections" version="3.2.2.v201511171945"/>
 <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
 <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
-<unit id="org.junit" version="4.11.0.v201303080030"/>
-<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+<unit id="org.junit" version="4.12.0.v201504281640"/>
+<unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+<unit id="org.slf4j.binding.simple" version="1.7.10.v20160301-1109"/>
+<unit id="org.slf4j.apis.log4j" version="1.7.10.v20160208-0839"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>

--- a/eclipse/target-definition/org.apache.sling.ide.target-definition.target
+++ b/eclipse/target-definition/org.apache.sling.ide.target-definition.target
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions
     and limitations under the License.
 -->
-<?pde version="3.8"?><target name="Sling IDE Tools" sequenceNumber="51">
+<?pde version="3.8"?><target name="Sling IDE Tools" sequenceNumber="52">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.0.20150526-2032"/>
@@ -23,14 +23,16 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
-<unit id="org.apache.commons.collections" version="3.2.0.v2013030210310"/>
+<unit id="org.apache.commons.collections" version="3.2.2.v201511171945"/>
 <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
 <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
-<unit id="org.junit" version="4.11.0.v201303080030"/>
-<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
+<unit id="org.junit" version="4.12.0.v201504281640"/>
+<unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+<unit id="org.slf4j.binding.simple" version="1.7.10.v20160301-1109"/>
+<unit id="org.slf4j.apis.log4j" version="1.7.10.v20160208-0839"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.9.2.v201802121827"/>

--- a/shared/modules/impl-vlt/pom.xml
+++ b/shared/modules/impl-vlt/pom.xml
@@ -46,6 +46,17 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <org.slf4j.simpleLogger.showDateTime>true</org.slf4j.simpleLogger.showDateTime>
+                        <org.slf4j.simpleLogger.dateTimeFormat>yyyy-MM-dd HH:mm:ss:SSS Z</org.slf4j.simpleLogger.dateTimeFormat>
+                        <org.slf4j.simpleLogger.defaultLogLevel>${defaultLogLevel}</org.slf4j.simpleLogger.defaultLogLevel>
+                    </systemProperties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -139,8 +150,15 @@
             <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <sling.java.version>8</sling.java.version>
+        <!-- Jackrabbit is quite verbose on INFO level -->
+        <defaultLogLevel>warn</defaultLogLevel>
     </properties>
 </project>


### PR DESCRIPTION
Switch to Sling 11 for ITs in hopes of increasing the success rate.

- use the slingstart-maven-plugin
- use preemptive authentication for the ExternalSlingLaunchpad ready check
- for the nodes reordering tests use an node type that is actually ordered to make
  sure the assertions are relevant.