### PR TITLE
SLING-11926 - Eclipse modules fail to build due to missing SWTBot dependency

### DIFF
--- a/eclipse/target-definition/org.apache.sling.ide.target-definition.target
+++ b/eclipse/target-definition/org.apache.sling.ide.target-definition.target
@@ -31,10 +31,9 @@
 			<unit id="org.mockito.mockito-core" version="0.0.0"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 		</location>
-		<!-- need new version due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=580708 -->
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<unit id="org.eclipse.swtbot.eclipse.feature.group" version="4.1.0.202304061555"/>
-	<repository location="https://download.eclipse.org/technology/swtbot/snapshots/"/>
+	<unit id="org.eclipse.swtbot.eclipse.feature.group" version="4.1.0.202306071420"/>
+	<repository location="https://download.eclipse.org/technology/swtbot/releases/4.1.0/"/>
 </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>


### PR DESCRIPTION
Switch to the latest SWTBot release. The snapshot we were using is no longer available, and the latest release is recent enough for our usage.