### PR TITLE
chore: include org.apache.commons.codec in the update site

### DIFF
--- a/eclipse/feature/feature.xml
+++ b/eclipse/feature/feature.xml
@@ -227,58 +227,38 @@
 
    <plugin
          id="org.apache.sling.ide.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.eclipse-core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.eclipse-ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.impl-vlt"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.slf4j.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.artifacts"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="com.google.gson"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.httpcomponents.httpclient"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.codec"
+         version="0.0.0"/>
 
 </feature>

--- a/eclipse/target-definition/org.apache.sling.ide.target-definition.target
+++ b/eclipse/target-definition/org.apache.sling.ide.target-definition.target
@@ -39,30 +39,31 @@
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
 		<unit id="com.google.gson" version="2.9.0.v20220704-0629"/>
 		<unit id="org.apache.httpcomponents.httpclient" version="4.5.13.v20210128-2225"/>
+    	<unit id="org.apache.commons.codec" version="1.14.0.v20200818-1422"/>
 	</location>
 	<!-- shared OSGi bundles -->
-	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.sling.ide</groupId>
-				<artifactId>org.apache.sling.ide.api</artifactId>
-				<version>1.2.3-SNAPSHOT</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.sling.ide</groupId>
-				<artifactId>org.apache.sling.ide.artifacts</artifactId>
-				<version>1.2.3-SNAPSHOT</version>
-				<type>jar</type>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.sling.ide</groupId>
-				<artifactId>org.apache.sling.ide.impl-vlt</artifactId>
-				<version>1.2.3-SNAPSHOT</version>
-				<type>jar</type>
-			</dependency>
-		</dependencies>
-	</location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.sling.ide</groupId>
+                <artifactId>org.apache.sling.ide.api</artifactId>
+                <version>1.2.3-SNAPSHOT</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling.ide</groupId>
+                <artifactId>org.apache.sling.ide.artifacts</artifactId>
+                <version>1.2.3-SNAPSHOT</version>
+                <type>jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling.ide</groupId>
+                <artifactId>org.apache.sling.ide.impl-vlt</artifactId>
+                <version>1.2.3-SNAPSHOT</version>
+                <type>jar</type>
+            </dependency>
+        </dependencies>
+    </location>
 </locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
At some point I observed installation errors that persisted until I added the commons-codec bundle to the update site. I can't reproduce them anymore but preserving the code in case the issue pops up again.