### PR TITLE
SLING-7596 - Ensure that the IDE tooling still works on Windows

### DIFF
--- a/cli/cli/src/test/java/org/apache/sling/ide/cli/impl/DirWatcherTest.java
+++ b/cli/cli/src/test/java/org/apache/sling/ide/cli/impl/DirWatcherTest.java
@@ -116,9 +116,9 @@ public class DirWatcherTest {
     
     @Test(timeout = 3000)
     public void deletedFile() throws IOException, InterruptedException {
-    	// TODO: does not work on Mac OS yet
+    	// TODO: does not work on Mac OS or Windows yet
     	assumeFalse(SystemUtils.IS_OS_MAC);
-        assumeFalse(SystemUtils.IS_OS_WINDOWS); // TODO - SLING-7596
+        assumeFalse(SystemUtils.IS_OS_WINDOWS); 
         
         File watchRoot = folder.newFolder();
         File subDir = new File(watchRoot, "subDir");


### PR DESCRIPTION
Dissociate the cli TODO from SLING-7596. The CLI is still experimental not shipped anywhere therefore it does not make sense to handle it as part of this issue.