### PR TITLE
SLING-12108 Start all bundles lazily

### DIFF
--- a/shared/api/bnd.bnd
+++ b/shared/api/bnd.bnd
@@ -1,2 +1,3 @@
+Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.io;version="[1.4,3)", \
   *

--- a/shared/artifacts/bnd.bnd
+++ b/shared/artifacts/bnd.bnd
@@ -1,0 +1,1 @@
+Bundle-ActivationPolicy: lazy

--- a/shared/impl-resource/bnd.bnd
+++ b/shared/impl-resource/bnd.bnd
@@ -1,0 +1,1 @@
+Bundle-ActivationPolicy: lazy

--- a/shared/sync-fs/bnd.bnd
+++ b/shared/sync-fs/bnd.bnd
@@ -1,0 +1,1 @@
+Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
This is crucial for Eclipse as otherwise this will transitively require too many bundles being started before the workspace is selected (which makes them fail).

Compare with related issue
https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/684