### PR TITLE
SLING-12108 Defer registration of the DebugOptionsListener service

### DIFF
--- a/eclipse/eclipse-core/META-INF/MANIFEST.MF
+++ b/eclipse/eclipse-core/META-INF/MANIFEST.MF
@@ -57,3 +57,12 @@ Provide-Capability: osgi.service;objectClass=org.apache.sling.ide.log.Logger
 Service-Component: OSGI-INF/org.apache.sling.ide.eclipse.core.debug.impl.Tracer.xml,
  OSGI-INF/org.apache.sling.ide.eclipse.core.logger.CompositeLogger.xml,
  OSGI-INF/org.apache.sling.ide.eclipse.core.logger.DefaultEclipseLogger.xml
+Require-Capability: osgi.service;filter:="(objectClass=org.apache.sling.ide.transport.RepositoryFactory)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.serialization.SerializationManager)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.filter.FilterLocator)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.osgi.OsgiClientFactory)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.artifacts.EmbeddedBundleLocator)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.log.Logger)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.transport.BatcherFactory)";
+ effective:=active,osgi.service;filter:="(objectClass=org.apache.sling.ide.sync.content.SyncCommandFactory)";
+ effective:=active

--- a/eclipse/eclipse-core/src/org/apache/sling/ide/eclipse/core/internal/Activator.java
+++ b/eclipse/eclipse-core/src/org/apache/sling/ide/eclipse/core/internal/Activator.java
@@ -60,10 +60,6 @@ public class Activator extends Plugin {
     private ExtendedServiceTracker<SyncCommandFactory> commandFactory;
     
     private Preferences preferences;
-    
-    public static final String BSN_VAULT_IMPL = "org.apache.sling.ide.impl-vlt";
-    public static final String BSN_API = "org.apache.sling.ide.api";
-    public static final String BSN_ARTIFACTS = "org.apache.sling.ide.artifacts";
 
 	public void start(BundleContext context) throws Exception {
         super.start(context);
@@ -77,16 +73,6 @@ public class Activator extends Plugin {
         batcherFactoryLocator = new ExtendedServiceTracker<>(context, BatcherFactory.class);
         sourceReferenceLocator = new ExtendedServiceTracker<>(context, SourceReferenceResolver.class);
         commandFactory = new ExtendedServiceTracker<>(context, SyncCommandFactory.class);
-	}
-
-	static Bundle getFirstBundle(BundleContext bundleContext, String bundleSymbolicName)
-	{
-		for (Bundle bundle : bundleContext.getBundles()) {
-			if (bundleSymbolicName.equals(bundle.getSymbolicName())) {
-				return bundle;
-			}
-		}
-		throw new IllegalStateException("Bundle with Bundle-SymbolicName '" + bundleSymbolicName + "' could not be found. Something went wrong during installation");
 	}
 
 	/*

--- a/eclipse/eclipse-ui/META-INF/MANIFEST.MF
+++ b/eclipse/eclipse-ui/META-INF/MANIFEST.MF
@@ -67,8 +67,7 @@ Require-Bundle: org.eclipse.ui.navigator;bundle-version="3.5.101",
  org.eclipse.jdt.ui,
  org.apache.sling.ide.eclipse-core,
  org.eclipse.ui.views.properties.tabbed
-Service-Component: ${tycho.ds.path}/org.apache.sling.ide.eclipse.ui.internal.console.SlingConsoleEventListener.xml,
- OSGI-INF/*.xml
+Service-Component: OSGI-INF/org.apache.sling.ide.eclipse.ui.internal.console.SlingConsoleLogger.xml
 Export-Package: org.apache.sling.ide.eclipse.ui,
  org.apache.sling.ide.eclipse.ui.browser,
  org.apache.sling.ide.eclipse.ui.console,

--- a/shared/parent/pom.xml
+++ b/shared/parent/pom.xml
@@ -44,8 +44,9 @@
                         <execution>
                             <id>bnd-process</id>
                             <configuration>
-                                <!-- due to the non-Maven standard merging this is effectively added to the config set in sling-bundle-parent -->
-                                <!-- make sure to automatically start this bundle in Equinox whenever some classes are referenced -->
+                                <!-- due to the non-Maven standard merging this is effectively added to the config set in sling-bundle-parent
+                                make sure to automatically start this bundle in Equinox whenever some classes are referenced
+                                (https://vogella.com/blog/getting-started-with-osgi-declarative-services-2024/#interlude-bundle-activationpolicy-lazy) -->
                                 <bnd>Bundle-ActivationPolicy: lazy</bnd>
                             </configuration>
                         </execution>


### PR DESCRIPTION
If registered via DS the whole bundle is activated eagerly by Eclipse due to the usage of the service tracker in
https://github.com/eclipse-equinox/equinox/blob/c6f8e3aab8d4f107d7836f21a2fc76823756ad73/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/debug/FrameworkDebugOptions.java#L138