### PR TITLE
SLING-8307 - Update the Eclipse tooling release process after the restructuring and code signing changes

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -187,7 +187,7 @@
     </build>
 
     <properties>
-        <tycho.version>4.0.3</tycho.version>
+        <tycho.version>4.0.13</tycho.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Use the latest available Tycho version from the 4.x stream. 5.x versions require Java 21 so let's not update for now.