### PR TITLE
SLING-8307 - Update the Eclipse tooling release process after the restructuring and code signing changes

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -192,6 +192,7 @@
         <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
+        <project.build.outputTimestamp />
     </properties>
 
     <profiles>


### PR DESCRIPTION
Unset the inherited project.build.outputTimestamp . This value is used by the tycho-packaging-plugin to calculate the qualifier and this ends up being the inherited value from the parent pom, which means that it does not change at all for local builds and nightlies.

Because of this all local builds and nightly releases have qualifier of 202306111641.

The value should be set only for releases.