### PR TITLE
SLING-8307 - Update the Eclipse tooling release process after the restructuring and code signing changes

### DIFF
--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -62,6 +62,7 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho.version}</version>
                 <configuration>
+                    <pomDependencies>consider</pomDependencies>
                     <target>
                         <artifact>
                             <groupId>${project.groupId}</groupId>
@@ -194,6 +195,28 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.outputTimestamp />
     </properties>
+
+    <!-- required for pomDependencies=consider target-platform-configuration -->
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.sling.ide</groupId>
+            <artifactId>org.apache.sling.ide.api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling.ide</groupId>
+            <artifactId>org.apache.sling.ide.artifacts</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling.ide</groupId>
+            <artifactId>org.apache.sling.ide.impl-vlt</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
     <profiles>
     	<profile>

--- a/eclipse/target-definition/org.apache.sling.ide.target-definition.target
+++ b/eclipse/target-definition/org.apache.sling.ide.target-definition.target
@@ -40,29 +40,6 @@
     	<unit id="com.google.gson"/>
     	<unit id="org.apache.httpcomponents.httpclient"/>
     </location>
-	<!-- shared OSGi bundles -->
-    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
-       <dependencies>
-           <dependency>
-               <groupId>org.apache.sling.ide</groupId>
-               <artifactId>org.apache.sling.ide.api</artifactId>
-               <version>1.2.3-SNAPSHOT</version>
-               <type>jar</type>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.sling.ide</groupId>
-               <artifactId>org.apache.sling.ide.artifacts</artifactId>
-               <version>1.2.3-SNAPSHOT</version>
-               <type>jar</type>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.sling.ide</groupId>
-               <artifactId>org.apache.sling.ide.impl-vlt</artifactId>
-               <version>1.2.3-SNAPSHOT</version>
-               <type>jar</type>
-           </dependency>
-       </dependencies>
-   </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Target platform dependencies of type Maven are not visible in Eclipse itself and are not easily updated during a release.

Therefore we use pomDependencies=consider and placeholders for the project version.

This does not change the development experience in the IDE.