### PR TITLE
SLING-12943 - Stop bundling third party dependencies with the eclipse feature

### DIFF
--- a/eclipse/feature/feature.xml
+++ b/eclipse/feature/feature.xml
@@ -227,51 +227,22 @@
 
    <plugin
          id="org.apache.sling.ide.api"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.eclipse-core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.eclipse-ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.impl-vlt"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.apache.sling.ide.artifacts"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.google.gson"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.apache.httpcomponents.httpclient"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
All dependencies are already included in recent Eclipse versions and this actually increases compatibility because our bundled plugins can not conflict anymore with that the runtime provides.