### PR TITLE
SLING-8307 - Update the Eclipse tooling release process after the restructuring and code signing changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ jcr.log
 atlassian-ide-plugin.xml
 derby.log
 bin
+
+/dist-staging/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ifndef RELEASE_VERSION
+$(error RELEASE_VERSION is not set)
+endif
+
+ifndef NEXT_VERSION
+$(error NEXT_VERSION is not set)
+endif
+
+SVN_DIST_ROOT=https://dist.apache.org/repos/dist/dev/sling/ide-tooling
+M2_REPO=$(HOME)/.m2/repository
+P2UPDATE_PATH=$(M2_REPO)/org/apache/sling/ide/org.apache.sling.ide.p2update/$(RELEASE_VERSION)
+SOURCE_BUNDLE_PATH=$(M2_REPO)/org/apache/sling/ide/org.apache.sling.ide.source-bundle/$(RELEASE_VERSION)
+P2UPDATE_FILE=org.apache.sling.ide.p2update-$(RELEASE_VERSION).zip
+SOURCE_BUNDLE_FILE=org.apache.sling.ide.source-bundle-$(RELEASE_VERSION).zip
+STAGING_DIR=dist-staging/$(RELEASE_VERSION)
+
+release: check-gpg release-shared release-eclipse prepare-dist-dir upload-to-dist-dev
+.PHONY=release
+
+# ensure that GPG signing will work in batch mode
+check-gpg:
+	gpg --sign README.md
+	rm -f README.md.gpg
+.PHONY=check-gpg
+
+release-shared:
+	cd shared && mvn --batch-mode release:prepare release:perform -DreleaseVersion=$(RELEASE_VERSION) -DdevelopmentVersion=$(NEXT_VERSION) -Dtag=sling-ide-tooling-shared-$(RELEASE_VERSION)
+
+.PHONY=release-shared
+
+release-eclipse:
+	cd eclipse && mvn --batch-mode versions:set-property -DgenerateBackupPoms=false -Dproperty=sling-ide.shared-deps.version -DnewVersion=$(RELEASE_VERSION) && git add pom.xml && git commit -m 'chore(deps): set shared-deps version to $(RELEASE_VERSION) for release'
+	cd eclipse && mvn --batch-mode release:prepare release:perform -DreleaseVersion=$(RELEASE_VERSION) -DdevelopmentVersion=$(NEXT_VERSION) -Dtag=sling-ide-tooling-eclipse-$(RELEASE_VERSION)
+	cd eclipse && mvn --batch-mode versions:set-property -DgenerateBackupPoms=false -Dproperty=sling-ide.shared-deps.version -DnewVersion=$(NEXT_VERSION) && git add pom.xml && git commit -m 'chore(deps): set shared-deps version to $(NEXT_VERSION) after the release'
+
+.PHONY=release-eclipse
+
+prepare-dist-dir:
+	rm -rf $(STAGING_DIR)
+	mkdir -p $(STAGING_DIR)
+	cp $(P2UPDATE_PATH)/$(P2UPDATE_FILE) $(STAGING_DIR)/
+	cp $(SOURCE_BUNDLE_PATH)/$(SOURCE_BUNDLE_FILE) $(STAGING_DIR)/
+	cp $(P2UPDATE_PATH)/$(P2UPDATE_FILE).asc $(STAGING_DIR)/
+	cp $(SOURCE_BUNDLE_PATH)/$(SOURCE_BUNDLE_FILE).asc $(STAGING_DIR)/
+	cd $(STAGING_DIR) && for f in $(P2UPDATE_FILE) $(SOURCE_BUNDLE_FILE); do \
+		openssl dgst -sha512 -r $$f | awk '{print $$1"  "$$2}' > $$f.sha512; \
+		openssl dgst -sha1 -r $$f | awk '{print $$1"  "$$2}' > $$f.sha1; \
+		openssl dgst -md5 -r $$f | awk '{print $$1"  "$$2}' > $$f.md5; \
+	done
+
+.PHONE=prepare-dist-dir
+
+upload-to-dist-dev:
+	@if svn ls $(SVN_DIST_ROOT)/$(RELEASE_VERSION) >/dev/null 2>&1; then \
+		echo "ERROR: Release version $(RELEASE_VERSION) already exists at $(SVN_DIST_ROOT)/$(RELEASE_VERSION)"; exit 1; \
+	else \
+		echo "SVN destination does not exist yet, proceeding with import"; \
+	fi
+	svn import -m "Uploading Sling IDE Tooling $(RELEASE_VERSION) release artifacts" $(STAGING_DIR) $(SVN_DIST_ROOT)/$(RELEASE_VERSION)
+
+.PHONY=upload-to-dist-dev
+
+clean-dist-staging:
+	rm -rf dist-staging
+
+.PHONY=clean-dist-staging

--- a/eclipse/eclipse-ui/pom.xml
+++ b/eclipse/eclipse-ui/pom.xml
@@ -27,6 +27,10 @@
   <packaging>eclipse-plugin</packaging>
   <name>Apache Sling IDE Tools Eclipse UI</name>
 
+  <properties>
+    <decentxml.version>1.4</decentxml.version>
+  </properties>
+
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-ide-tooling.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-ide-tooling.git</developerConnection>
@@ -65,7 +69,7 @@
                     <artifactItem>
                         <groupId>de.pdark</groupId>
                         <artifactId>decentxml</artifactId>
-                        <version>1.4</version>
+                        <version>${decentxml.version}</version>
                     </artifactItem>                           
                 </artifactItems>
                 <outputDirectory>lib</outputDirectory>
@@ -77,6 +81,19 @@
                     </goals>
                 </execution>
             </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+                <additionalDependencies>
+                    <additionalDependency>
+                        <groupId>de.pdark</groupId>
+                        <artifactId>decentxml</artifactId>
+                        <version>${decentxml.version}</version>
+                    </additionalDependency>
+                </additionalDependencies>
+            </configuration>
         </plugin>
         <plugin>
 			<groupId>org.eclipse.tycho</groupId>

--- a/eclipse/p2update/pom.xml
+++ b/eclipse/p2update/pom.xml
@@ -85,13 +85,6 @@
 						</execution>
 					</executions>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-release-plugin</artifactId>
-					<configuration>
-						<releaseProfiles>apache-release,sign-with-gpg</releaseProfiles>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -134,6 +134,38 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <!-- When releasing we build the modules locally and include them in the p2 repository
+                but we do not release them on Maven Central. To be revisited if needed -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>clean install</goals>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <releaseProfiles>apache-release,sign-with-gpg</releaseProfiles>
+                    <!-- See https://wiki.eclipse.org/Tycho/Release_Workflow -->
+                    <preparationGoals>org.eclipse.tycho:tycho-versions-plugin:${tycho.version}:update-eclipse-metadata org.apache.maven.plugins:maven-scm-plugin:1.9.5:add org.apache.maven.plugins:maven-scm-plugin:1.9.5:checkin</preparationGoals>
+                    <completionGoals>org.eclipse.tycho:tycho-versions-plugin:${tycho.version}:update-eclipse-metadata org.apache.maven.plugins:maven-scm-plugin:1.9.5:add org.apache.maven.plugins:maven-scm-plugin:1.9.5:checkin</completionGoals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>add</goal>
+                            <goal>checkin</goal>
+                        </goals>
+                        <configuration>
+                            <includes>**/META-INF/MANIFEST.MF,**/feature.xml,**/*.product,**/category.xml</includes>
+                            <excludes>**/target/**</excludes>
+                            <message>chore: change the version to reflect the pom versions for the release</message>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -47,6 +47,8 @@
         <module>eclipse-sightly-ui</module>
         <module>sightly-feature</module>
         <!-- test modules activated per profile -->
+        <module>p2update</module>
+        <module>source-bundle</module>
     </modules>
 
     <build>
@@ -234,9 +236,6 @@
                     </plugin>
                 </plugins>
             </build>
-            <modules>
-            	<module>p2update</module>
-            </modules>
         </profile>
         <profile>
             <id>eclipse-test</id>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -189,6 +189,7 @@
 
     <properties>
         <tycho.version>4.0.13</tycho.version>
+        <sling-ide.shared-deps.version>1.2.3-SNAPSHOT</sling-ide.shared-deps.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
         <maven.compiler.target>17</maven.compiler.target>
@@ -201,19 +202,19 @@
         <dependency>
             <groupId>org.apache.sling.ide</groupId>
             <artifactId>org.apache.sling.ide.api</artifactId>
-            <version>${project.version}</version>
+            <version>${sling-ide.shared-deps.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling.ide</groupId>
             <artifactId>org.apache.sling.ide.artifacts</artifactId>
-            <version>${project.version}</version>
+            <version>${sling-ide.shared-deps.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling.ide</groupId>
             <artifactId>org.apache.sling.ide.impl-vlt</artifactId>
-            <version>${project.version}</version>
+            <version>${sling-ide.shared-deps.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/eclipse/source-bundle/assembly.xml
+++ b/eclipse/source-bundle/assembly.xml
@@ -26,7 +26,7 @@
         <!-- create a source zip of project's complete source -->
         <fileSet>
             <directory>${project.basedir}/../</directory>
-            <outputDirectory>${project.build.finalName}</outputDirectory>
+            <outputDirectory>eclipse</outputDirectory>
             <excludes>
                 <exclude>**/target/**</exclude>
                 <exclude>**/*.jar</exclude>
@@ -41,6 +41,19 @@
         <fileSet>
             <directory>${project.build.directory}/maven-shared-archive-resources</directory>
             <outputDirectory></outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../../shared</directory>
+            <outputDirectory>shared</outputDirectory>
+            <excludes>
+                <exclude>**/target/**</exclude>
+                <exclude>**/*.jar</exclude>
+                <exclude>**/.project</exclude>
+                <exclude>**/.classpath</exclude>
+                <exclude>**/.settings/**</exclude>
+                <exclude>**/*.class</exclude>
+                <exclude>**/derby.log</exclude>
+            </excludes>
         </fileSet>
     </fileSets>
 </assembly>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -31,6 +31,21 @@
         <url>https://github.com/apache/sling-ide-tooling.git</url>
     </scm>
 
+    <build>
+        <plugins>
+            <plugin>
+                <!-- When releasing we build the modules locally and include them in the p2 repository
+                but we do not release them on Maven Central. To be revisited if needed -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <goals>clean install</goals>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <modules>
         <module>parent</module>
         <module>api</module>


### PR DESCRIPTION
The release process is fully automated up until the release candidate is staged https://dist.apache.org/repos/dist/dev/sling/ide-tooling (upload itself not yet tested).