### PR TITLE
SLING-12965 Fix initialization of debugOptionsListenerRegistration

### DIFF
--- a/eclipse/eclipse-core/src/org/apache/sling/ide/eclipse/core/debug/impl/Tracer.java
+++ b/eclipse/eclipse-core/src/org/apache/sling/ide/eclipse/core/debug/impl/Tracer.java
@@ -47,7 +47,7 @@ public class Tracer implements DebugOptionsListener, LogSubscriber {
     @Activate
     public void activate(BundleContext context) {
         // defer registration of the DebugOptionsListener service until this component is activated, otherwise this bundle is eagerly loaded by Equinox
-        context.registerService(DebugOptionsListener.class, this, null);
+        debugOptionsListenerRegistration = context.registerService(DebugOptionsListener.class, this, null);
     }
 
     @Deactivate


### PR DESCRIPTION
This prevents the NPE during Tracer.deactivate()